### PR TITLE
Adopt Anthropics MCP Java SDK for stdio server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,16 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.modelcontextprotocol.sdk</groupId>
+            <artifactId>mcp</artifactId>
+            <version>0.13.1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.modelcontextprotocol.sdk</groupId>
+            <artifactId>mcp-json-jackson2</artifactId>
+            <version>0.13.1</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.17.1</version>
@@ -40,6 +50,12 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
             <version>1.11.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.16</version>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary
- replace the bespoke JSON-RPC loop with an Anthropics MCP Java SDK stdio server
- expose the existing migration tools via SDK tool descriptors and structured call results
- add the MCP SDK dependencies and an slf4j binding to the Maven build

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68d7ed86e3708329a919cbe77da8ac23