### PR TITLE
Handle non-UTF8 sources when extracting JPA native queries

### DIFF
--- a/src/main/java/com/example/mcp/util/QueryExtractor.java
+++ b/src/main/java/com/example/mcp/util/QueryExtractor.java
@@ -8,6 +8,7 @@ import org.apache.commons.text.StringEscapeUtils;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
@@ -76,12 +77,16 @@ public class QueryExtractor {
     }
 
     private String readContent(Path file) throws IOException {
+        byte[] bytes = Files.readAllBytes(file);
         CharsetDecoder decoder = StandardCharsets.UTF_8
                 .newDecoder()
                 .onMalformedInput(CodingErrorAction.REPLACE)
                 .onUnmappableCharacter(CodingErrorAction.REPLACE);
-        ByteBuffer buffer = ByteBuffer.wrap(Files.readAllBytes(file));
-        return decoder.decode(buffer).toString();
+        try {
+            return decoder.decode(ByteBuffer.wrap(bytes)).toString();
+        } catch (CharacterCodingException ex) {
+            return new String(bytes, StandardCharsets.ISO_8859_1);
+        }
     }
 
     private String detectRepoName(String content, String fallback) {


### PR DESCRIPTION
## Summary
- ensure `QueryExtractor` tolerates non-UTF-8 source files by replacing malformed characters or falling back to ISO-8859-1 decoding

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68d7f50974248329a8e579c094175b60