### PR TITLE
Fix native query flag detection

### DIFF
--- a/src/main/java/com/example/mcp/util/QueryExtractor.java
+++ b/src/main/java/com/example/mcp/util/QueryExtractor.java
@@ -27,6 +27,7 @@ public class QueryExtractor {
             "\"\"\"([\\s\\S]*?)\"\"\"|\"(\\\\.|[^\\\\\"])*\""
     );
     private static final Pattern METHOD_PATTERN = Pattern.compile("(?:public|protected|private|default)?\\s*(?:static\\s+)?[\\w<>,\\s\\[\\]]+\\s+(\\w+)\\s*\\(");
+    private static final Pattern NATIVE_QUERY_FLAG_PATTERN = Pattern.compile("nativequery\\s*=\\s*true");
 
     private final RuleEngine ruleEngine;
 
@@ -111,7 +112,7 @@ public class QueryExtractor {
                 continue;
             }
             String normalizedBody = body.toLowerCase(Locale.ROOT);
-            if (!normalizedBody.contains("nativequery=true")) {
+            if (!NATIVE_QUERY_FLAG_PATTERN.matcher(normalizedBody).find()) {
                 searchStart = matcher.end();
                 continue;
             }


### PR DESCRIPTION
## Summary
- allow the JPA native-query scanner to detect `nativeQuery = true` declarations even when whitespace surrounds the equals sign
- reuse a precompiled regex to avoid repeated pattern creation during extraction

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68d7fac193ac8329b0426d4183fcffa9