### PR TITLE
Support fully qualified Query annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,18 @@
             <version>2.0.16</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -86,6 +98,11 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/example/mcp/util/QueryExtractor.java
+++ b/src/main/java/com/example/mcp/util/QueryExtractor.java
@@ -22,7 +22,7 @@ import java.util.regex.Pattern;
 
 public class QueryExtractor {
     private static final Pattern CLASS_PATTERN = Pattern.compile("(public\\s+)?(class|interface)\\s+(\\w+)");
-    private static final Pattern QUERY_PATTERN = Pattern.compile("@Query\\s*\\(");
+    private static final Pattern QUERY_PATTERN = Pattern.compile("@(?:[A-Za-z_][\\w$]*\\.)*Query\\s*\\(");
     private static final Pattern STRING_PATTERN = Pattern.compile(
             "\"\"\"([\\s\\S]*?)\"\"\"|\"(\\\\.|[^\\\\\"])*\""
     );

--- a/src/test/java/com/example/mcp/tools/JpaListNativeQueriesToolTest.java
+++ b/src/test/java/com/example/mcp/tools/JpaListNativeQueriesToolTest.java
@@ -1,0 +1,100 @@
+package com.example.mcp.tools;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class JpaListNativeQueriesToolTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void detectsNativeQueriesIncludingTextBlocks() throws Exception {
+        Path sourceDir = tempDir.resolve("src/main/java/com/example/demo");
+        Files.createDirectories(sourceDir);
+        Path repositoryFile = sourceDir.resolve("DemoRepository.java");
+        Files.writeString(repositoryFile, repositorySource());
+
+        ObjectMapper mapper = new ObjectMapper();
+        JpaListNativeQueriesTool tool = new JpaListNativeQueriesTool(mapper);
+        ObjectNode args = mapper.createObjectNode();
+        ArrayNode rootDirs = mapper.createArrayNode();
+        rootDirs.add(tempDir.toString());
+        args.set("rootDirs", rootDirs);
+
+        JsonNode result = tool.call(args);
+        ArrayNode queries = (ArrayNode) result.get("queries");
+
+        assertNotNull(queries, "queries node should be present");
+        assertEquals(3, queries.size(), "should detect all native queries");
+        assertContainsQuery(queries, "DemoRepository#countAllNative", "SELECT COUNT(*) FROM demo_records where numer=?1");
+        assertContainsQuery(queries, "DemoRepository#findAllNamesNative", "SELECT name FROM demo_records where name= :name ORDER BY name");
+        assertContainsQuery(queries, "DemoRepository#countAllNative1", "WITH employee_data AS (");
+    }
+
+    private String repositorySource() {
+        return "package com.example.demo;\n" +
+                "\n" +
+                "import org.springframework.data.jpa.repository.JpaRepository;\n" +
+                "import org.springframework.data.jpa.repository.Query;\n" +
+                "import org.springframework.stereotype.Repository;\n" +
+                "\n" +
+                "import java.util.List;\n" +
+                "\n" +
+                "@Repository\n" +
+                "public interface DemoRepository extends JpaRepository<DemoEntity, Long> {\n" +
+                "\n" +
+                "    @Query(value = \"SELECT COUNT(*) FROM demo_records where numer=?1\", nativeQuery = true)\n" +
+                "    Long countAllNative(Long number);\n" +
+                "\n" +
+                "    @org.springframework.data.jpa.repository.Query(value = \"SELECT name FROM demo_records where name= :name ORDER BY name\", nativeQuery = true)\n" +
+                "    List<Object> findAllNamesNative(String name);\n" +
+                "\n" +
+                "    @Query(value = \"\"\"\n" +
+                "WITH employee_data AS (\n" +
+                "    SELECT 100 AS employee_id, 'Steven King' AS employee_name, NULL AS manager_id FROM DUAL UNION ALL\n" +
+                "    SELECT 101 AS employee_id, 'Neena Kochhar' AS employee_name, 100 AS manager_id FROM DUAL UNION ALL\n" +
+                "    SELECT 102 AS employee_id, 'Lex De Haan' AS employee_name, 100 AS manager_id FROM DUAL UNION ALL\n" +
+                "    SELECT 103 AS employee_id, 'Alexander Hunold' AS employee_name, 102 AS manager_id FROM DUAL UNION ALL\n" +
+                "    SELECT 104 AS employee_id, 'Bruce Ernst' AS employee_name, 103 AS manager_id FROM DUAL\n" +
+                ")\n" +
+                "SELECT\n" +
+                "    employee_id,\n" +
+                "    LPAD(' ', (LEVEL - 1) * 2) || employee_name AS indented_name, \n" +
+                "    LEVEL, \n" +
+                "    SYS_CONNECT_BY_PATH(employee_name, ' / ') AS path \n" +
+                "FROM\n" +
+                "    employee_data\n" +
+                "START WITH\n" +
+                "    manager_id IS NULL \n" +
+                "CONNECT BY\n" +
+                "    PRIOR employee_id = manager_id\n" +
+                "\"\"\", nativeQuery = true)\n" +
+                "    Long countAllNative1();\n" +
+                "}\n";
+    }
+    private void assertContainsQuery(ArrayNode queries, String id, String expectedSqlFragment) {
+        for (JsonNode query : queries) {
+            if (id.equals(query.get("id").asText())) {
+                String sql = query.get("sqlRaw").asText();
+                assertNotNull(sql, "sql should be present for " + id);
+                if (!sql.contains(expectedSqlFragment)) {
+                    fail("SQL for " + id + " did not contain expected fragment");
+                }
+                return;
+            }
+        }
+        fail("Expected query with id " + id + " not found");
+    }
+}


### PR DESCRIPTION
## Summary
- ensure native query extraction recognises fully qualified @Query annotations
- add test coverage for native queries including text blocks and qualified annotations
- wire up JUnit 5 test dependencies and surefire plugin to execute the new tests

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68d801f0e4e883298f4389efdeadd23e