### PR TITLE
Wrap IN clause placeholders with parentheses

### DIFF
--- a/src/test/java/com/example/mcp/util/ParamNormalizerTest.java
+++ b/src/test/java/com/example/mcp/util/ParamNormalizerTest.java
@@ -1,0 +1,35 @@
+package com.example.mcp.util;
+
+import com.example.mcp.model.Placeholder;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ParamNormalizerTest {
+
+    @Test
+    void wrapsInClausePlaceholdersWithParentheses() {
+        ParamNormalizer.Result result = ParamNormalizer.normalize("select * from dummy where id in ?1");
+
+        assertEquals("select * from dummy where id in (?)", result.sql());
+        assertEquals(List.of("?1"), result.placeholders().stream().map(Placeholder::token).toList());
+    }
+
+    @Test
+    void keepsExistingParenthesesAroundInClausePlaceholders() {
+        ParamNormalizer.Result result = ParamNormalizer.normalize("select * from dummy where id in (?1)");
+
+        assertEquals("select * from dummy where id in (?)", result.sql());
+        assertEquals(List.of("?1"), result.placeholders().stream().map(Placeholder::token).toList());
+    }
+
+    @Test
+    void wrapsNamedParametersInInClause() {
+        ParamNormalizer.Result result = ParamNormalizer.normalize("select * from dummy where id in :ids");
+
+        assertEquals("select * from dummy where id in (?)", result.sql());
+        assertEquals(List.of(":ids"), result.placeholders().stream().map(Placeholder::token).toList());
+    }
+}


### PR DESCRIPTION
## Summary
- wrap normalized placeholders in parentheses when they appear after an IN keyword
- add unit tests covering positional and named parameters inside IN clauses

## Testing
- mvn -q test

------
https://chatgpt.com/codex/tasks/task_e_68da5323333883298f7bed7b8840c90d