### PR TITLE
Add pagination metadata and truncation options to native query tool

### DIFF
--- a/src/main/java/com/example/mcp/tools/JpaListNativeQueriesTool.java
+++ b/src/main/java/com/example/mcp/tools/JpaListNativeQueriesTool.java
@@ -15,9 +15,10 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -26,6 +27,8 @@ import java.util.stream.Collectors;
 
 public class JpaListNativeQueriesTool implements Tool {
     private static final int MAX_THREADS = 15;
+    private static final int DEFAULT_LIMIT = 50;
+    private static final int MAX_LIMIT = 500;
 
     private final ObjectMapper mapper;
     private final QueryExtractor extractor;
@@ -53,6 +56,15 @@ public class JpaListNativeQueriesTool implements Tool {
         properties.set("rootDirs", arrayOfStrings());
         properties.set("includeGlobs", arrayOfStrings());
         properties.set("excludeGlobs", arrayOfStrings());
+        properties.set("limit", paginationField(
+                "Maximum number of results to return (default " + DEFAULT_LIMIT + ", max " + MAX_LIMIT + ").",
+                DEFAULT_LIMIT, 1));
+        properties.set("cursor", paginationField(
+                "Zero-based index from which to continue the result set.", null, 0));
+        properties.set("offset", paginationField(
+                "Alias for cursor.", null, 0));
+        properties.set("maxSqlLength", paginationField(
+                "Optional maximum length for SQL text fields; longer queries will be truncated.", null, 1));
         schema.set("properties", properties);
         ArrayNode required = mapper.createArrayNode();
         required.add("rootDirs");
@@ -75,9 +87,12 @@ public class JpaListNativeQueriesTool implements Tool {
         List<String> includeGlobs = readStringArray(arguments.get("includeGlobs"));
         List<String> excludeGlobs = readStringArray(arguments.get("excludeGlobs"));
 
-        ArrayNode queriesNode = mapper.createArrayNode();
+        int limit = determineLimit(arguments);
+        int cursor = determineCursor(arguments);
+        Integer maxSqlLength = determineMaxSqlLength(arguments);
+
+        Map<String, QueryItem> deduped = new LinkedHashMap<>();
         ArrayNode errorsNode = mapper.createArrayNode();
-        Set<String> seen = new HashSet<>();
         for (Path root : roots) {
             if (!Files.exists(root)) {
                 continue;
@@ -115,9 +130,7 @@ public class JpaListNativeQueriesTool implements Tool {
                     }
                     for (QueryItem item : result.items()) {
                         String key = item.id() + "@" + item.file();
-                        if (seen.add(key)) {
-                            queriesNode.add(serialize(item));
-                        }
+                        deduped.putIfAbsent(key, item);
                     }
                     for (String error : result.errors()) {
                         errorsNode.add(error);
@@ -127,12 +140,65 @@ public class JpaListNativeQueriesTool implements Tool {
                 executor.shutdownNow();
             }
         }
+        List<QueryItem> allItems = new ArrayList<>(deduped.values());
+        allItems.sort(Comparator.comparing(QueryItem::file, Comparator.nullsLast(String::compareTo))
+                .thenComparing(QueryItem::id, Comparator.nullsLast(String::compareTo)));
+
+        int totalCount = allItems.size();
+        int startIndex = Math.max(Math.min(cursor, totalCount), 0);
+        int effectiveLimit = Math.max(1, Math.min(limit, MAX_LIMIT));
+        int endIndex = Math.min(startIndex + effectiveLimit, totalCount);
+
+        List<QueryItem> page = allItems.subList(startIndex, endIndex);
+        ArrayNode queriesNode = mapper.createArrayNode();
+        for (QueryItem item : page) {
+            queriesNode.add(serialize(item, maxSqlLength));
+        }
+
         ObjectNode result = mapper.createObjectNode();
         result.set("queries", queriesNode);
+        result.put("totalCount", totalCount);
+        result.put("limit", effectiveLimit);
+        result.put("cursor", startIndex);
+        if (endIndex < totalCount) {
+            result.put("nextCursor", endIndex);
+        }
         if (!errorsNode.isEmpty()) {
             result.set("errors", errorsNode);
         }
         return result;
+    }
+
+    private int determineLimit(JsonNode arguments) {
+        JsonNode limitNode = arguments.get("limit");
+        int requested = limitNode != null && limitNode.isNumber()
+                ? limitNode.asInt(DEFAULT_LIMIT)
+                : DEFAULT_LIMIT;
+        if (requested < 1) {
+            requested = 1;
+        }
+        return Math.min(requested, MAX_LIMIT);
+    }
+
+    private int determineCursor(JsonNode arguments) {
+        JsonNode cursorNode = arguments.has("cursor") ? arguments.get("cursor") : arguments.get("offset");
+        if (cursorNode == null || !cursorNode.isNumber()) {
+            return 0;
+        }
+        int cursor = cursorNode.asInt(0);
+        return Math.max(cursor, 0);
+    }
+
+    private Integer determineMaxSqlLength(JsonNode arguments) {
+        JsonNode node = arguments.get("maxSqlLength");
+        if (node == null || !node.isNumber()) {
+            return null;
+        }
+        int value = node.asInt();
+        if (value < 1) {
+            return null;
+        }
+        return value;
     }
 
     private boolean shouldInclude(Path root, Path file, List<String> includes, List<String> excludes) {
@@ -191,14 +257,14 @@ public class JpaListNativeQueriesTool implements Tool {
         }
     }
 
-    private ObjectNode serialize(QueryItem item) {
+    private ObjectNode serialize(QueryItem item, Integer maxSqlLength) {
         ObjectNode node = mapper.createObjectNode();
         node.put("id", item.id());
         node.put("file", item.file());
         node.put("repo", item.repo());
         putNullable(node, "method", item.method());
-        node.put("sqlRaw", item.sqlRaw());
-        node.put("sqlNormalized", item.sqlNormalized());
+        node.put("sqlRaw", maybeTruncate(item.sqlRaw(), maxSqlLength));
+        node.put("sqlNormalized", maybeTruncate(item.sqlNormalized(), maxSqlLength));
         ArrayNode placeholders = mapper.createArrayNode();
         for (Placeholder placeholder : item.placeholders()) {
             ObjectNode placeholderNode = mapper.createObjectNode();
@@ -216,6 +282,22 @@ public class JpaListNativeQueriesTool implements Tool {
         }
         node.set("ruleHits", hits);
         return node;
+    }
+
+    private String maybeTruncate(String value, Integer maxSqlLength) {
+        if (value == null || maxSqlLength == null) {
+            return value;
+        }
+        if (value.length() <= maxSqlLength) {
+            return value;
+        }
+        if (maxSqlLength == 1) {
+            return "…";
+        }
+        if (maxSqlLength == 2) {
+            return value.substring(0, 1) + "…";
+        }
+        return value.substring(0, maxSqlLength - 1) + "…";
     }
 
     private void putNullable(ObjectNode node, String key, String value) {
@@ -239,6 +321,17 @@ public class JpaListNativeQueriesTool implements Tool {
             return path.replace('/', '\\');
         }
         return path.replace('\\', '/');
+    }
+
+    private ObjectNode paginationField(String description, Integer defaultValue, int minimum) {
+        ObjectNode node = mapper.createObjectNode();
+        node.put("type", "integer");
+        node.put("minimum", minimum);
+        node.put("description", description);
+        if (defaultValue != null) {
+            node.put("default", defaultValue);
+        }
+        return node;
     }
 
     private record FileScanResult(List<QueryItem> items, List<String> errors) {

--- a/src/test/java/com/example/mcp/tools/JpaListNativeQueriesToolTest.java
+++ b/src/test/java/com/example/mcp/tools/JpaListNativeQueriesToolTest.java
@@ -9,9 +9,13 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 class JpaListNativeQueriesToolTest {
@@ -21,26 +25,78 @@ class JpaListNativeQueriesToolTest {
 
     @Test
     void detectsNativeQueriesIncludingTextBlocks() throws Exception {
-        Path sourceDir = tempDir.resolve("src/main/java/com/example/demo");
-        Files.createDirectories(sourceDir);
-        Path repositoryFile = sourceDir.resolve("DemoRepository.java");
-        Files.writeString(repositoryFile, repositorySource());
+        writeRepositorySource();
 
         ObjectMapper mapper = new ObjectMapper();
         JpaListNativeQueriesTool tool = new JpaListNativeQueriesTool(mapper);
-        ObjectNode args = mapper.createObjectNode();
-        ArrayNode rootDirs = mapper.createArrayNode();
-        rootDirs.add(tempDir.toString());
-        args.set("rootDirs", rootDirs);
+        ObjectNode args = defaultArguments(mapper);
 
         JsonNode result = tool.call(args);
         ArrayNode queries = (ArrayNode) result.get("queries");
 
         assertNotNull(queries, "queries node should be present");
         assertEquals(3, queries.size(), "should detect all native queries");
+        assertEquals(3, result.get("totalCount").asInt());
+        assertEquals(0, result.get("cursor").asInt());
+        assertEquals(50, result.get("limit").asInt());
         assertContainsQuery(queries, "DemoRepository#countAllNative", "SELECT COUNT(*) FROM demo_records where numer=?1");
         assertContainsQuery(queries, "DemoRepository#findAllNamesNative", "SELECT name FROM demo_records where name= :name ORDER BY name");
         assertContainsQuery(queries, "DemoRepository#countAllNative1", "WITH employee_data AS (");
+    }
+
+    @Test
+    void paginatesResultsUsingCursor() throws Exception {
+        writeRepositorySource();
+
+        ObjectMapper mapper = new ObjectMapper();
+        JpaListNativeQueriesTool tool = new JpaListNativeQueriesTool(mapper);
+
+        ObjectNode firstArgs = defaultArguments(mapper);
+        firstArgs.put("limit", 2);
+
+        JsonNode firstResult = tool.call(firstArgs);
+        ArrayNode firstPage = (ArrayNode) firstResult.get("queries");
+        assertEquals(2, firstPage.size(), "first page should honor limit");
+        assertEquals(3, firstResult.get("totalCount").asInt());
+        assertEquals(0, firstResult.get("cursor").asInt());
+        assertEquals(2, firstResult.get("limit").asInt());
+        assertEquals(2, firstResult.get("nextCursor").asInt());
+
+        ObjectNode secondArgs = defaultArguments(mapper);
+        secondArgs.put("cursor", firstResult.get("nextCursor").asInt());
+        secondArgs.put("limit", 2);
+
+        JsonNode secondResult = tool.call(secondArgs);
+        ArrayNode secondPage = (ArrayNode) secondResult.get("queries");
+        assertEquals(1, secondPage.size(), "second page should contain remaining item");
+        assertEquals(3, secondResult.get("totalCount").asInt());
+        assertEquals(2, secondResult.get("cursor").asInt());
+        assertNull(secondResult.get("nextCursor"), "nextCursor should be absent when no more data");
+
+        Set<String> collectedIds = new HashSet<>();
+        firstPage.forEach(node -> collectedIds.add(node.get("id").asText()));
+        secondPage.forEach(node -> collectedIds.add(node.get("id").asText()));
+        assertEquals(3, collectedIds.size(), "pagination should expose every query across pages");
+    }
+
+    @Test
+    void truncatesSqlWhenMaxSqlLengthProvided() throws Exception {
+        writeRepositorySource();
+
+        ObjectMapper mapper = new ObjectMapper();
+        JpaListNativeQueriesTool tool = new JpaListNativeQueriesTool(mapper);
+
+        ObjectNode args = defaultArguments(mapper);
+        args.put("maxSqlLength", 20);
+
+        JsonNode result = tool.call(args);
+        ArrayNode queries = (ArrayNode) result.get("queries");
+        for (JsonNode query : queries) {
+            JsonNode sqlRaw = query.get("sqlRaw");
+            JsonNode sqlNormalized = query.get("sqlNormalized");
+            assertTrue(sqlRaw.isNull() || sqlRaw.asText().length() <= 20, "sqlRaw should be truncated when requested");
+            assertTrue(sqlNormalized.isNull() || sqlNormalized.asText().length() <= 20, "sqlNormalized should be truncated when requested");
+        }
     }
 
     private String repositorySource() {
@@ -96,5 +152,20 @@ class JpaListNativeQueriesToolTest {
             }
         }
         fail("Expected query with id " + id + " not found");
+    }
+
+    private ObjectNode defaultArguments(ObjectMapper mapper) {
+        ObjectNode args = mapper.createObjectNode();
+        ArrayNode rootDirs = mapper.createArrayNode();
+        rootDirs.add(tempDir.toString());
+        args.set("rootDirs", rootDirs);
+        return args;
+    }
+
+    private void writeRepositorySource() throws Exception {
+        Path sourceDir = tempDir.resolve("src/main/java/com/example/demo");
+        Files.createDirectories(sourceDir);
+        Path repositoryFile = sourceDir.resolve("DemoRepository.java");
+        Files.writeString(repositoryFile, repositorySource());
     }
 }


### PR DESCRIPTION
## Summary
- add limit, cursor/offset, and maxSqlLength inputs to the native query listing tool while clamping abusive limits
- collect, sort, and paginate deduplicated query items, returning totalCount and nextCursor metadata for callers
- extend tests to cover pagination flows and SQL truncation behavior

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68da88c8d4788329bdeae634dd3bdebb