### PR TITLE
Add prepare report tool for SQL diagnostics logging

### DIFF
--- a/src/main/java/com/example/mcp/tools/PrepareReportTool.java
+++ b/src/main/java/com/example/mcp/tools/PrepareReportTool.java
@@ -1,0 +1,98 @@
+package com.example.mcp.tools;
+
+import com.example.mcp.util.JarLocationResolver;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+
+public class PrepareReportTool implements Tool {
+
+    private static final String REPORT_FILE_NAME = "prepare-report.csv";
+
+    private final ObjectMapper mapper;
+
+    public PrepareReportTool(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    public String getName() {
+        return "h2.prepare.report";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Append SQL and LLM diagnostic feedback to the shared preparation report.";
+    }
+
+    @Override
+    public ObjectNode getInputSchema() {
+        ObjectNode schema = mapper.createObjectNode();
+        schema.put("type", "object");
+        ObjectNode properties = mapper.createObjectNode();
+        properties.putObject("sql").put("type", "string");
+        properties.putObject("diagnosis").put("type", "string");
+        schema.set("properties", properties);
+        var required = mapper.createArrayNode();
+        required.add("sql");
+        required.add("diagnosis");
+        schema.set("required", required);
+        return schema;
+    }
+
+    @Override
+    public JsonNode call(JsonNode arguments) throws IOException {
+        String sql = arguments.path("sql").asText(null);
+        String diagnosis = arguments.path("diagnosis").asText(null);
+        if (sql == null || diagnosis == null) {
+            throw new IllegalArgumentException("'sql' and 'diagnosis' are required");
+        }
+
+        Path reportPath = resolveReportPath();
+        boolean newFile = Files.notExists(reportPath);
+        if (newFile) {
+            Path parent = reportPath.getParent();
+            if (parent != null && Files.notExists(parent)) {
+                Files.createDirectories(parent);
+            }
+        }
+
+        try (var writer = Files.newBufferedWriter(reportPath, StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE, StandardOpenOption.APPEND)) {
+            if (newFile) {
+                writer.write("timestamp,sql,diagnosis\n");
+            }
+            writer.write(formatCsvValue(Instant.now().toString()));
+            writer.write(',');
+            writer.write(formatCsvValue(sql));
+            writer.write(',');
+            writer.write(formatCsvValue(diagnosis));
+            writer.write('\n');
+        }
+
+        ObjectNode result = mapper.createObjectNode();
+        result.put("reportPath", reportPath.toAbsolutePath().toString());
+        result.put("appended", true);
+        return result;
+    }
+
+    private Path resolveReportPath() {
+        Path jarDirectory = JarLocationResolver.resolveJarDirectory(PrepareReportTool.class);
+        if (jarDirectory != null) {
+            return jarDirectory.resolve(REPORT_FILE_NAME);
+        }
+        return Path.of(REPORT_FILE_NAME);
+    }
+
+    private String formatCsvValue(String value) {
+        String escaped = value.replace("\"", "\"\"");
+        return '"' + escaped + '"';
+    }
+}

--- a/src/main/java/com/example/mcp/util/JarLocationResolver.java
+++ b/src/main/java/com/example/mcp/util/JarLocationResolver.java
@@ -1,0 +1,39 @@
+package com.example.mcp.util;
+
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.CodeSource;
+
+public final class JarLocationResolver {
+
+    private JarLocationResolver() {
+    }
+
+    public static Path resolveJarDirectory(Class<?> referenceClass) {
+        CodeSource codeSource = referenceClass.getProtectionDomain().getCodeSource();
+        if (codeSource == null) {
+            return null;
+        }
+
+        URL location = codeSource.getLocation();
+        if (location == null) {
+            return null;
+        }
+
+        try {
+            Path resolvedPath = Paths.get(location.toURI());
+            if (Files.isRegularFile(resolvedPath)) {
+                return resolvedPath.getParent();
+            }
+            if (Files.isDirectory(resolvedPath)) {
+                return resolvedPath;
+            }
+        } catch (URISyntaxException e) {
+            return null;
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- add a prepare report tool that appends SQL and diagnosis feedback to a shared CSV beside the server jar
- register the new tool after the H2 prepare tool and factor out jar location resolution logic

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68da9352557c832989ea5bf08973e957